### PR TITLE
Swap UI crashes with certain slippage percentages

### DIFF
--- a/src/components/PageHeader/SlippageToleranceSetting.tsx
+++ b/src/components/PageHeader/SlippageToleranceSetting.tsx
@@ -54,7 +54,7 @@ const SlippageToleranceSettings = () => {
 
   const handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const { value: inputValue } = evt.target
-    setValue(parseFloat(inputValue))
+    setValue(Math.round(parseFloat(inputValue)))
   }
 
   // Updates local storage if value is valid

--- a/src/components/PageHeader/SlippageToleranceSetting.tsx
+++ b/src/components/PageHeader/SlippageToleranceSetting.tsx
@@ -62,7 +62,7 @@ const SlippageToleranceSettings = () => {
     try {
       const rawValue = value * 100
       if (!Number.isNaN(rawValue) && rawValue > 0 && rawValue < MAX_SLIPPAGE) {
-        setUserslippageTolerance(rawValue)
+        setUserslippageTolerance(Math.round(rawValue))
         setError(null)
       } else {
         setError('Enter a valid slippage percentage')

--- a/src/components/PageHeader/SlippageToleranceSetting.tsx
+++ b/src/components/PageHeader/SlippageToleranceSetting.tsx
@@ -54,7 +54,7 @@ const SlippageToleranceSettings = () => {
 
   const handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const { value: inputValue } = evt.target
-    setValue(Math.round(parseFloat(inputValue)))
+    setValue(parseFloat(inputValue))
   }
 
   // Updates local storage if value is valid

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -109,7 +109,7 @@ export function useExpertModeManager(): [boolean, () => void] {
 export function useUserSlippageTolerance(): [number, (slippage: number) => void] {
   const dispatch = useDispatch<AppDispatch>()
   const userSlippageTolerance = useSelector<AppState, AppState['user']['userSlippageTolerance']>((state) => {
-    return state.user.userSlippageTolerance
+    return Math.round(state.user.userSlippageTolerance)
   })
 
   const setUserSlippageTolerance = useCallback(


### PR DESCRIPTION
Issue Description 

Swap UI crashes when selecting certain slippage percentages. (2,2)
Floating point issue, too many decimals for BigInt to parse.

Solution

Round values returned from the userSlippageTolerance state.
Round values before storing userSlippageTolerance state.